### PR TITLE
Fixes minoutsize so large files no longer fail

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "CodecLz4"
 uuid = "5ba52731-8f18-5e0d-9241-30f10d1ec561"
 license = "MIT"
 author = "Invenia Technical Computing"
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 BinDeps = "9e28174c-4ba2-5203-b857-d8d62c4213ee"

--- a/src/CodecLz4.jl
+++ b/src/CodecLz4.jl
@@ -20,9 +20,7 @@ struct LZ4Exception <: Exception
     msg::AbstractString
 end
 
-function Base.showerror(io::IO, ex::LZ4Exception)
-    printstyled(io, "$(ex.src): $(ex.msg)", color=Base.error_color())
-end
+Base.showerror(io::IO, ex::LZ4Exception) = print(io, "$(ex.src): $(ex.msg)")
 
 include("lz4frame.jl")
 include("stream_compression.jl")

--- a/src/CodecLz4.jl
+++ b/src/CodecLz4.jl
@@ -20,7 +20,7 @@ struct LZ4Exception <: Exception
     msg::AbstractString
 end
 
-function Base.showerror(io::IO, ex::LZ4Exception, bt; backtrace=false)
+function Base.showerror(io::IO, ex::LZ4Exception)
     printstyled(io, "$(ex.src): $(ex.msg)", color=Base.error_color())
 end
 

--- a/src/stream_compression.jl
+++ b/src/stream_compression.jl
@@ -62,7 +62,7 @@ end
 Returns the minimum output size of `process`.
 """
 function TranscodingStreams.minoutsize(codec::LZ4Compressor, input::Memory)::Int
-    LZ4F_HEADER_SIZE_MAX
+    LZ4F_compressBound(input.size, codec.prefs)
 end
 
 """

--- a/test/stream_compression.jl
+++ b/test/stream_compression.jl
@@ -109,3 +109,19 @@ end
     @test frame.blockChecksumFlag == Cuint(1)
 
 end
+
+@testset "dst size fix" begin
+    teststring = rand(UInt8, 800000)
+    io = IOBuffer(teststring)
+    stream = LZ4CompressorStream(io)
+    result = read(stream)
+    @test_nowarn close(stream)
+    close(io)
+
+    io = IOBuffer(result)
+    stream = LZ4DecompressorStream(io)
+    result = read(stream)
+    @test result == teststring
+    @test_nowarn close(stream)
+    close(io)
+end


### PR DESCRIPTION
Also allows errors to display backtrace.
Should fix https://github.com/invenia/CodecLz4.jl/issues/21.