### PR TITLE
Dropping support for Julia 0.6

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,6 +1,8 @@
 environment:
   matrix:
-  - julia_version: 1
+  - julia_version: 1.0
+  - julia_version: 1.1
+  - julia_version: 1.2
   - julia_version: nightly
 
 platform:

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@
 /deps/src
 /deps/usr
 /deps/build.log
-Manifest.toml
+/Manifest.toml

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@
 *.jl.mem
 /docs/build/
 /docs/site/
-/docs/Manifest.toml
 /deps/deps.jl
 /deps/downloads
 /deps/src

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.jl.mem
 /docs/build/
 /docs/site/
+/docs/Manifest.toml
 /deps/deps.jl
 /deps/downloads
 /deps/src

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ os:
 julia:
   - 1.0
   - 1.1
+  - 1.2
   - nightly
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,6 @@ jobs:
       julia: 1.0
       os: linux
       script:
-        - julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
+        - julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate(); Pkg.build()'
         - julia --project=docs/ docs/make.jl
       after_success: skip

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,12 @@ notifications:
   email: false
 after_success:
   - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
+jobs:
+  include:
+    - stage: "Documentation"
+      julia: 1.0
+      os: linux
+      script:
+        - julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
+        - julia --project=docs/ docs/make.jl
+      after_success: skip

--- a/Project.toml
+++ b/Project.toml
@@ -12,3 +12,9 @@ TranscodingStreams = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
 
 [compat]
 julia = "1"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,12 +1,14 @@
 name = "CodecLz4"
 uuid = "5ba52731-8f18-5e0d-9241-30f10d1ec561"
+license = "MIT"
+author = "Invenia Technical Computing"
 version = "0.2.0"
-
-[compat]
-julia = "1"
 
 [deps]
 BinDeps = "9e28174c-4ba2-5203-b857-d8d62c4213ee"
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 TranscodingStreams = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
+
+[compat]
+julia = "1"

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,7 +1,6 @@
 using BinDeps
-using Compat.Libdl
+using Libdl
 using Base.Sys: WORD_SIZE
-import Compat.Sys
 @BinDeps.setup
 
 function validate_lz4(name,handle)

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -1,0 +1,136 @@
+# This file is machine-generated - editing it directly is not advised
+
+[[Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[BinDeps]]
+deps = ["Compat", "Libdl", "SHA", "URIParser"]
+git-tree-sha1 = "12093ca6cdd0ee547c39b1870e0c9c3f154d9ca9"
+uuid = "9e28174c-4ba2-5203-b857-d8d62c4213ee"
+version = "0.8.10"
+
+[[CodecLz4]]
+deps = ["BinDeps", "Compat", "Libdl", "TranscodingStreams"]
+path = ".."
+uuid = "5ba52731-8f18-5e0d-9241-30f10d1ec561"
+version = "0.2.0"
+
+[[Compat]]
+deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
+git-tree-sha1 = "84aa74986c5b9b898b0d1acaf3258741ee64754f"
+uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
+version = "2.1.0"
+
+[[Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[DelimitedFiles]]
+deps = ["Mmap"]
+uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+
+[[Distributed]]
+deps = ["Random", "Serialization", "Sockets"]
+uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+
+[[DocStringExtensions]]
+deps = ["LibGit2", "Markdown", "Pkg", "Test"]
+git-tree-sha1 = "4d30e889c9f106a51ffa4791a88ffd4765bf20c3"
+uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+version = "0.7.0"
+
+[[Documenter]]
+deps = ["Base64", "DocStringExtensions", "InteractiveUtils", "JSON", "LibGit2", "Logging", "Markdown", "REPL", "Unicode"]
+git-tree-sha1 = "bb727cddc81525c55b70b56c3691fbf244d7728f"
+uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+version = "0.22.5"
+
+[[InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[JSON]]
+deps = ["Dates", "Distributed", "Mmap", "Sockets", "Test", "Unicode"]
+git-tree-sha1 = "1f7a25b53ec67f5e9422f1f551ee216503f4a0fa"
+uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+version = "0.20.0"
+
+[[LibGit2]]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[LinearAlgebra]]
+deps = ["Libdl"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[[Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[Mmap]]
+uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+
+[[Pkg]]
+deps = ["Dates", "LibGit2", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+[[Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[REPL]]
+deps = ["InteractiveUtils", "Markdown", "Sockets"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[Random]]
+deps = ["Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[SharedArrays]]
+deps = ["Distributed", "Mmap", "Random", "Serialization"]
+uuid = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
+
+[[Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[SparseArrays]]
+deps = ["LinearAlgebra", "Random"]
+uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[[Statistics]]
+deps = ["LinearAlgebra", "SparseArrays"]
+uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[[Test]]
+deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[TranscodingStreams]]
+deps = ["Random", "Test"]
+git-tree-sha1 = "a25d8e5a28c3b1b06d3859f30757d43106791919"
+uuid = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
+version = "0.9.4"
+
+[[URIParser]]
+deps = ["Test", "Unicode"]
+git-tree-sha1 = "6ddf8244220dfda2f17539fa8c9de20d6c575b69"
+uuid = "30578b45-9adc-5946-b283-645ec420af67"
+version = "0.4.0"
+
+[[UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[[Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,6 @@
+[deps]
+CodecLz4 = "5ba52731-8f18-5e0d-9241-30f10d1ec561"
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+
+[compat]
+Documenter = "~0.22.4"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,20 +2,18 @@ using Documenter, CodecLz4
 
 makedocs(;
     modules=[CodecLz4],
-    format=:html,
+    format=Documenter.HTML(),
     pages=[
         "Home" => "index.md",
     ],
     repo="https://github.com/invenia/CodecLz4.jl/blob/{commit}{path}#L{line}",
     sitename="CodecLz4.jl",
     authors="Invenia Technical Computing Corporation",
-    assets=[],
 )
 
 deploydocs(;
     repo="github.com/invenia/CodecLz4.jl",
     target="build",
-    julia="0.6",
     deps=nothing,
     make=nothing,
 )

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -8,5 +8,4 @@
 
 ```@autodocs
 Modules = [CodecLz4]
-Pages = ["CodecLz4.jl", "lz4frame.jl", "stream_compression.jl"]
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -5,3 +5,8 @@
 [![Build Status](https://travis-ci.org/invenia/CodecLz4.jl.svg?branch=master)](https://travis-ci.org/invenia/CodecLz4.jl)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/invenia/CodecLz4.jl?svg=true)](https://ci.appveyor.com/project/invenia/codeclz4-jl)
 [![CodeCov](https://codecov.io/gh/invenia/CodecLz4.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/invenia/CodecLz4.jl)
+
+```@autodocs
+Modules = [CodecLz4]
+Pages = ["CodecLz4.jl", "lz4frame.jl", "stream_compression.jl"]
+```

--- a/src/CodecLz4.jl
+++ b/src/CodecLz4.jl
@@ -1,6 +1,5 @@
 __precompile__()
 module CodecLz4
-using Compat
 using TranscodingStreams: TranscodingStream, Memory, Error
 using TranscodingStreams
 export LZ4Compressor, LZ4CompressorStream,

--- a/src/stream_compression.jl
+++ b/src/stream_compression.jl
@@ -69,7 +69,7 @@ function TranscodingStreams.initialize(codec::LZ4Compressor)::Nothing
     nothing
 end
 
-"""
+""" 
 Finalizes the LZ4F Compression Codec.
 """
 function TranscodingStreams.finalize(codec::LZ4Compressor)::Nothing
@@ -170,7 +170,7 @@ function TranscodingStreams.finalize(codec::LZ4Decompressor)::Nothing
 end
 
 """
-Deompresses the data from `input` and writes to `output`.
+Decompresses the data from `input` and writes to `output`.
 If the input data is not properly formatted this function will throw an error.
 """
 function TranscodingStreams.process(codec::LZ4Decompressor, input::Memory, output::Memory, error::Error)::Tuple{Int,Int,Symbol}

--- a/src/stream_compression.jl
+++ b/src/stream_compression.jl
@@ -48,6 +48,8 @@ function LZ4CompressorStream(stream::IO; kwargs...)
 end
 
 """
+    TranscodingStreams.expectedsize(codec::LZ4Compressor, input::Memory)
+
 Returns the expected size of the transcoded data.
 """
 function TranscodingStreams.expectedsize(codec::LZ4Compressor, input::Memory)::Int
@@ -55,6 +57,8 @@ function TranscodingStreams.expectedsize(codec::LZ4Compressor, input::Memory)::I
 end
 
 """
+   TranscodingStreams.minoutsize(codec::LZ4Compressor, input::Memory) 
+
 Returns the minimum output size of `process`.
 """
 function TranscodingStreams.minoutsize(codec::LZ4Compressor, input::Memory)::Int
@@ -62,6 +66,8 @@ function TranscodingStreams.minoutsize(codec::LZ4Compressor, input::Memory)::Int
 end
 
 """
+   TranscodingStreams.initialize(codec::LZ4Compressor) 
+
 Initializes the LZ4F Compression Codec.
 """
 function TranscodingStreams.initialize(codec::LZ4Compressor)::Nothing
@@ -70,6 +76,8 @@ function TranscodingStreams.initialize(codec::LZ4Compressor)::Nothing
 end
 
 """
+    TranscodingStreams.finalize(codec::LZ4Compressor)
+
 Finalizes the LZ4F Compression Codec.
 """
 function TranscodingStreams.finalize(codec::LZ4Compressor)::Nothing
@@ -78,6 +86,8 @@ function TranscodingStreams.finalize(codec::LZ4Compressor)::Nothing
 end
 
 """
+    TranscodingStreams.startproc(codec::LZ4Compressor, mode::Symbol, error::Error)
+
 Starts processing with the codec
 Creates the LZ4F header to be written to the output.
 """
@@ -95,6 +105,8 @@ function TranscodingStreams.startproc(codec::LZ4Compressor, mode::Symbol, error:
 end
 
 """
+    TranscodingStreams.process(codec::LZ4Compressor, input::Memory, output::Memory, error::Error)
+
 Compresses the data from `input` and writes to `output`.
 The LZ4 compression algorithm may simply buffer the input data a full frame can be produced, so `data_written` may be 0.
 `flush()` may be used to force `output` to be written.
@@ -154,6 +166,8 @@ function LZ4DecompressorStream(stream::IO; kwargs...)
 end
 
 """
+    TranscodingStreams.initialize(codec::LZ4Decompressor)
+
 Initializes the LZ4F Decompression Codec.
 """
 function TranscodingStreams.initialize(codec::LZ4Decompressor)::Nothing
@@ -162,6 +176,8 @@ function TranscodingStreams.initialize(codec::LZ4Decompressor)::Nothing
 end
 
 """
+    TranscodingStreams.finalize(codec::LZ4Decompressor)
+
 Finalizes the LZ4F Decompression Codec.
 """
 function TranscodingStreams.finalize(codec::LZ4Decompressor)::Nothing
@@ -170,6 +186,8 @@ function TranscodingStreams.finalize(codec::LZ4Decompressor)::Nothing
 end
 
 """
+    TranscodingStreams.process(codec::LZ4Decompressor, input::Memory, output::Memory, error::Error)
+
 Decompresses the data from `input` and writes to `output`.
 If the input data is not properly formatted this function will throw an error.
 """

--- a/src/stream_compression.jl
+++ b/src/stream_compression.jl
@@ -69,7 +69,7 @@ function TranscodingStreams.initialize(codec::LZ4Compressor)::Nothing
     nothing
 end
 
-""" 
+"""
 Finalizes the LZ4F Compression Codec.
 """
 function TranscodingStreams.finalize(codec::LZ4Compressor)::Nothing

--- a/test/lz4frame.jl
+++ b/test/lz4frame.jl
@@ -1,4 +1,3 @@
-using Compat
 @testset "lz4frame" begin
      testIn = "Far out in the uncharted backwaters of the unfashionable end of the west-
  ern  spiral  arm  of  the  Galaxy  lies  a  small  unregarded  yellow  sun."

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
-using Compat.Test
 using CodecLz4
+using Test
 
 @testset "CodecLz4.jl" begin
     include("lz4frame.jl")


### PR DESCRIPTION
Summary of changes
---
- AppVeyor: Jobs for Julia `1.1`, `1.2`
- Travis: Job for Julia `1.2`; build documentation
- Ignore the `/docs/Manifest.toml`
- Added author and license attributes in `Project.toml`
- Removed references to Compat
- Resolved various warnings with Documenter

Testing
---
```
   Testing CodecLz4
 Resolving package versions...
Test Summary: | Pass  Total
CodecLz4.jl   |  359    359
   Testing CodecLz4 tests passed 
```

Notes
---
- When building the documentation the warning below appears. Manually looking through the generated documentation there are docstrs generated for each of those functions.

```
┌ Warning: 9 docstrings potentially missing:
│ 
│     CodecLz4.process :: Tuple{LZ4Decompressor,TranscodingStreams.Memory,TranscodingStreams.Memory,TranscodingStreams.Error}
│     CodecLz4.process :: Tuple{LZ4Compressor,TranscodingStreams.Memory,TranscodingStreams.Memory,TranscodingStreams.Error}
│     CodecLz4.minoutsize :: Tuple{LZ4Compressor,TranscodingStreams.Memory}
│     CodecLz4.expectedsize :: Tuple{LZ4Compressor,TranscodingStreams.Memory}
│     Base.finalize :: Tuple{LZ4Decompressor}
│     Base.finalize :: Tuple{LZ4Compressor}
│     CodecLz4.initialize :: Tuple{LZ4Decompressor}
│     CodecLz4.initialize :: Tuple{LZ4Compressor}
│     CodecLz4.startproc :: Tuple{LZ4Compressor,Symbol,TranscodingStreams.Error}
└ @ Documenter.DocChecks ~/.julia/packages/Documenter/jU36S/src/DocChecks.jl:62
```